### PR TITLE
Labels and titles for latex environments

### DIFF
--- a/pandoc_latex_environment.py
+++ b/pandoc_latex_environment.py
@@ -25,7 +25,13 @@ def environment(key, value, format, meta):
                 else:
                     label = ''
 
-                value[1] = [RawBlock('tex', '\\begin{' + environment + '}' + label)] + content + [RawBlock('tex', '\\end{' + environment + '}')]
+                currentProperties = dict(properties)
+                if 'title' in currentProperties:
+                    title = '[' + currentProperties['title'] + ']'
+                else:
+                    title = ''
+
+                value[1] = [RawBlock('tex', '\\begin{' + environment + '}' + title + label)] + content + [RawBlock('tex', '\\end{' + environment + '}')]
                 break
 
 def getDefined(meta):

--- a/pandoc_latex_environment.py
+++ b/pandoc_latex_environment.py
@@ -20,7 +20,12 @@ def environment(key, value, format, meta):
         for environment, definedClasses in getDefined(meta).items():
             # Is the classes correct?
             if currentClasses >= definedClasses:
-                value[1] = [RawBlock('tex', '\\begin{' + environment + '}')] + content + [RawBlock('tex', '\\end{' + environment + '}')]
+                if id != '':
+                    label = ' \\label{' + id + '}'
+                else:
+                    label = ''
+
+                value[1] = [RawBlock('tex', '\\begin{' + environment + '}' + label)] + content + [RawBlock('tex', '\\end{' + environment + '}')]
                 break
 
 def getDefined(meta):
@@ -43,4 +48,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -180,3 +180,98 @@ def test_empty():
 
     assert json.loads(json.dumps(src)) == dest
 
+
+def test_div_with_id():
+    init()
+
+    meta = {
+        'pandoc-latex-environment': {
+            'c': {
+                'test': {
+                    'c': [
+                        {
+                            'c': [
+                                {
+                                    'c': 'class1',
+                                    't': 'Str'
+                                }
+                            ],
+                            't': 'MetaInlines'
+                        },
+                        {
+                            'c': [
+                                {
+                                    'c': 'class2',
+                                    't': 'Str'
+                                }
+                            ],
+                            't': 'MetaInlines'
+                        }
+                    ],
+                    't': 'MetaList'
+                }
+            },
+            't': 'MetaMap'
+        }
+    }
+
+    src = json.loads(json.dumps(Div(
+        [
+            'identifier',
+            [
+                'class1',
+                'class2'
+            ],
+            []
+        ],
+        [
+            {
+                'c': [
+                    {
+                        'c': 'content',
+                        't': 'Str'
+                    }
+                ],
+                't': 'Plain'
+            }
+        ]
+    )))
+    dest = json.loads(json.dumps(Div(
+        [
+            'identifier',
+            [
+                'class1',
+                'class2'
+            ],
+            []
+        ],
+        [
+            {
+                'c': [
+                    'tex',
+                    '\\begin{test} \\label{identifier}'
+                ],
+                't': 'RawBlock'
+            },
+            {
+                'c': [
+                    {
+                        'c': 'content',
+                        't': 'Str'
+                    }
+                ],
+                't': 'Plain'
+            },
+            {
+                'c': [
+                    'tex',
+                    '\\end{test}'
+                ],
+                't': 'RawBlock'
+            }
+        ]
+    )))
+
+    pandoc_latex_environment.environment(src['t'], src['c'], 'latex', meta)
+
+    assert json.loads(json.dumps(src)) == dest

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -275,3 +275,103 @@ def test_div_with_id():
     pandoc_latex_environment.environment(src['t'], src['c'], 'latex', meta)
 
     assert json.loads(json.dumps(src)) == dest
+
+
+def test_div_with_title():
+    init()
+
+    meta = {
+        'pandoc-latex-environment': {
+            'c': {
+                'test': {
+                    'c': [
+                        {
+                            'c': [
+                                {
+                                    'c': 'class1',
+                                    't': 'Str'
+                                }
+                            ],
+                            't': 'MetaInlines'
+                        },
+                        {
+                            'c': [
+                                {
+                                    'c': 'class2',
+                                    't': 'Str'
+                                }
+                            ],
+                            't': 'MetaInlines'
+                        }
+                    ],
+                    't': 'MetaList'
+                }
+            },
+            't': 'MetaMap'
+        }
+    }
+
+    src = json.loads(json.dumps(Div(
+        [
+            '',
+            [
+                'class1',
+                'class2'
+            ],
+            [
+                ['title', 'theTitle']
+            ]
+        ],
+        [
+            {
+                'c': [
+                    {
+                        'c': 'content',
+                        't': 'Str'
+                    }
+                ],
+                't': 'Plain'
+            }
+        ]
+    )))
+    dest = json.loads(json.dumps(Div(
+        [
+            '',
+            [
+                'class1',
+                'class2'
+            ],
+            [
+                ['title', 'theTitle']
+            ]
+        ],
+        [
+            {
+                'c': [
+                    'tex',
+                    '\\begin{test}[theTitle]'
+                ],
+                't': 'RawBlock'
+            },
+            {
+                'c': [
+                    {
+                        'c': 'content',
+                        't': 'Str'
+                    }
+                ],
+                't': 'Plain'
+            },
+            {
+                'c': [
+                    'tex',
+                    '\\end{test}'
+                ],
+                't': 'RawBlock'
+            }
+        ]
+    )))
+
+    pandoc_latex_environment.environment(src['t'], src['c'], 'latex', meta)
+
+    assert json.loads(json.dumps(src)) == dest


### PR DESCRIPTION
I've added two features to your script that I found useful. I've created this PR in case you think they'd be generally useful.

1.  If a converted div has an `id` attribute, then use that as a `\label` within the latex environment.
2.  If a converted div has a `title` attribute, then pass that as an optional argument to the latex environment.

For example:

~~~ {.markdown}
---
pandoc-latex-environment:
    theorem: [theorem]
---
<div id="thm:cantor" title="Cantor's Theorem" class="theorem">
Every set has more subsets than elements.
</div>
~~~

This converts to:

~~~ {.latex}
\begin{theorem}[Cantor's Theorem] \label{thm:cantor}

Every set has more subsets than elements.

\end{theorem}
~~~

I'm using this together with another filter that converts certain internal links to latex cross-references, which is why the `\label{thm:cantor}` is useful.

One other note: in the tests, you had the same metadata construction repeated in multiple tests. I copied this style in the new tests I added, since I didn't know if you had a reason for it, but I think  it would probably make sense to factor that out to simplify the testing code. I'm happy to make that minor change if you'd like me to do it.

Thanks for sharing your helpful filters!

Best,
Jeff
