### PR TITLE
Fix non-paragraph elements in divs

### DIFF
--- a/pandoc_latex_environment.py
+++ b/pandoc_latex_environment.py
@@ -4,7 +4,7 @@
 Pandoc filter for adding LaTeX environement on specific div
 """
 
-from pandocfilters import toJSONFilters, stringify, RawInline, Para
+from pandocfilters import toJSONFilters, stringify, RawBlock, Para
 
 import re
 
@@ -21,7 +21,7 @@ def environment(key, value, format, meta):
             # Is the classes correct?
             if currentClasses >= definedClasses:
                 if id != '':
-                    label = '\\label{' + id + '}'
+                    label = '\n\\label{' + id + '}'
                 else:
                     label = ''
 
@@ -31,28 +31,10 @@ def environment(key, value, format, meta):
                 else:
                     title = ''
                 
-                # fix an empty block not rendering any output
-                if len(content) == 0:
-                    content = [Para([])]
-                
-                newconts = []
-                pos = 0
-                last = len(content)
-                for node in content:
-                    replacement = node['c']
-                    pos += 1
-                    if pos == 1:
-                        replacement = [RawInline('tex', '\\begin{' + environment + '}' + title + '\n' + label)] + replacement
-                    if pos == last:
-                        replacement = replacement + [RawInline('tex', '\n\\end{' + environment + '}')]
-                    newconts.append(
-                        {
-                            't': node['t'],
-                            'c': replacement
-                        }
-                    )
+                before = RawBlock('tex', '\\begin{' + environment + '}' + title + label)
+                after = RawBlock('tex', '\\end{' + environment + '}')
 
-                value[1] = newconts
+                value[1] = [before] + content + [after]
                 break
 
 def getDefined(meta):

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -74,23 +74,22 @@ def test_div():
             ],
             []
         ],
-        [
+        [      
             {
-                't': 'Plain',
+                't': 'RawBlock',
+                'c': ['tex', '\\begin{test}']
+            },
+            {
                 'c': [
-                    {
-                        't': 'RawInline',
-                        'c': ['tex', '\\begin{test}\n']
-                    },
-                    {
-                        'c': 'content',
-                        't': 'Str'
-                    },
-                    {
-                        't': 'RawInline',
-                        'c': ['tex', '\n\\end{test}']
-                    }
-                ]
+                {
+                    'c': 'content',
+                    't': 'Str'
+                }],
+                't': 'Plain'
+            },
+            {
+                't': 'RawBlock',
+                'c': ['tex', '\\end{test}']
             }
         ]
     )))
@@ -230,6 +229,7 @@ def test_div_with_id():
             }
         ]
     )))
+
     dest = json.loads(json.dumps(Div(
         [
             'identifier',
@@ -239,23 +239,22 @@ def test_div_with_id():
             ],
             []
         ],
-        [
+        [      
             {
-                't': 'Plain',
+                't': 'RawBlock',
+                'c': ['tex', '\\begin{test}\n\\label{identifier}']
+            },
+            {
                 'c': [
-                    {
-                        't': 'RawInline',
-                        'c': ['tex', '\\begin{test}\n\\label{identifier}']
-                    },
-                    {
-                        'c': 'content',
-                        't': 'Str'
-                    },
-                    {
-                        't': 'RawInline',
-                        'c': ['tex', '\n\\end{test}']
-                    }
-                ]
+                {
+                    'c': 'content',
+                    't': 'Str'
+                }],
+                't': 'Plain'
+            },
+            {
+                't': 'RawBlock',
+                'c': ['tex', '\\end{test}']
             }
         ]
     )))
@@ -322,6 +321,7 @@ def test_div_with_title():
             }
         ]
     )))
+    
     dest = json.loads(json.dumps(Div(
         [
             '',
@@ -333,28 +333,26 @@ def test_div_with_title():
                 ['title', 'theTitle']
             ]
         ],
-        [
+        [      
             {
-                't': 'Plain',
+                't': 'RawBlock',
+                'c': ['tex', '\\begin{test}[theTitle]']
+            },
+            {
                 'c': [
-                    {
-                        't': 'RawInline',
-                        'c': ['tex', '\\begin{test}[theTitle]\n']
-                    },
-                    {
-                        'c': 'content',
-                        't': 'Str'
-                    },
-                    {
-                        't': 'RawInline',
-                        'c': ['tex', '\n\\end{test}']
-                    }
-                ]
+                {
+                    'c': 'content',
+                    't': 'Str'
+                }],
+                't': 'Plain'
+            },
+            {
+                't': 'RawBlock',
+                'c': ['tex', '\\end{test}']
             }
         ]
     )))
 
     pandoc_latex_environment.environment(src['t'], src['c'], 'latex', meta)
 
-    print(json.loads(json.dumps(src)))
     assert json.loads(json.dumps(src)) == dest


### PR DESCRIPTION
This addresses issue #9.

This patch changes the behavior of the script in all cases. The previous behavior was to add a `RawInline` element to the beginning of the first child of a `Div`, and another `RawInline` element to the end of the last child. This behavior made sense if the first and last children were `Plain` or `Para`, but in general could break, leading to a crash.

The new behavior is to add a `RawBlock` child as the first child of the `Div`, and another `RawBlock` as the last child. The existing child nodes are unmodified. (This approach also simplifies the code.)

It looks like in latex output this has the effect of including some extra newlines surrounding the raw latex code. In latex output this may result in some extra whitespace, depending on the environment. Since the pandoc latex writer seems to add newlines to pretty much any top-level element (`RawBlock`, `Plain`) this seems hard to avoid. But I may be missing something.
