### PR TITLE
temp fix for stringify not converting MetaString, allowing metadata in defaults file

### DIFF
--- a/pandoc_latex_environment.py
+++ b/pandoc_latex_environment.py
@@ -46,7 +46,11 @@ def getDefined(meta):
                 if classes['t'] == 'MetaList':
                     getDefined.value[environment] = []
                     for klass in classes['c']:
-                        string = stringify(klass)
+                        if klass['t']=='MetaString':  # this happens when metadata comes from a defaults file
+                            string = klass['c']
+                        else:
+                            string = stringify(klass)  # stringify currently cannot convert MetaString object - reported upstream
+
                         if re.match('^[a-zA-Z][\w.:-]*$', string):
                             getDefined.value[environment].append(string)
                     getDefined.value[environment] = set(getDefined.value[environment])

--- a/pandoc_latex_environment.py
+++ b/pandoc_latex_environment.py
@@ -46,10 +46,10 @@ def getDefined(meta):
                 if classes['t'] == 'MetaList':
                     getDefined.value[environment] = []
                     for klass in classes['c']:
-                        if klass['t']=='MetaString':  # this happens when metadata comes from a defaults file
-                            string = klass['c']
+                        if not isinstance(klass,list):  # this happens when metadata comes from a defaults file
+                            string = stringify( [ klass ] ) # stringify needs a list (tree) to operate on
                         else:
-                            string = stringify(klass)  # stringify currently cannot convert MetaString object - reported upstream
+                            string = stringify(klass)
 
                         if re.match('^[a-zA-Z][\w.:-]*$', string):
                             getDefined.value[environment].append(string)


### PR DESCRIPTION
When metadata is stored in the metadata section of a defaults file,
some of the strings are stored as `MetaString` objects, instead of
`MetaInline` (which is the case when metadata comes from the document
header).

Unfortunately, pandoc's `stringify` currently does not work on MetaString
objects, so this provides a temporary workaround. (This issue has been
reported upstream at https://github.com/jgm/pandoc/issues/7149.)

With this fix, metadata can now be stored in a defaults yaml file, for example:

```
metadata:
  pandoc-latex-environment:
    noteblock: [note]
    tipblock: [tip]
    warningblock: [warning]
    cautionblock: [caution]
    importantblock: [important]
```